### PR TITLE
Bump com.github.spotbugs from 4.6.1 to 4.6.2 (#26)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     checkstyle
     id("com.github.johnrengelman.shadow") version "6.1.0"
     id("com.gorylenko.gradle-git-properties") version "2.2.4"
-    id("com.github.spotbugs") version "4.6.1"
+    id("com.github.spotbugs") version "4.6.2"
 }
 
 tasks.create<Copy>("copyHooks") {


### PR DESCRIPTION
# Description

Bumps com.github.spotbugs from 4.6.1 to 4.6.2.

## Type of change

- [x] Feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Hotfix (non-breaking change which fixes an issue directly on prod)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Another project needs to be merged before this PR (List PRs that have to be merged in advance)

# Checklist

- [x] My code follows the style guidelines of Minecraft Legend
- [x] I have performed a self-review of my own code
- [x] I have tested my feature or bugfix
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules